### PR TITLE
Add bignum classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add a new vector cl
 
 *Classes that wrap numbers.*
 
+* [`biginteger`](https://davidchall.github.io/bignum/reference/biginteger.html) - Arbitrary precision integers: [`25852016738884976640000`](reprex/biginteger.md)
+* [`bigfloat`](https://davidchall.github.io/bignum/reference/bigfloat.html) - High precision numbers: [`0.33333333333333333333333333333333333333333333333333`](reprex/bigfloat.md)
 * [`errors`](https://r-quantities.github.io/errors/reference/errors.html) - Numbers with uncertainty: [`1 ± 0.3`](reprex/errors.md)
 * [`num`](https://pillar.r-lib.org/reference/num) - Numbers with formatting: [`1.00`](reprex/num.md)
 * [`quantities`](https://r-quantities.github.io/quantities/reference/quantities.html) - Numbers with units and uncertainty: [`1 ± 0.3 [m/s]`](reprex/quantities.md)

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add a new vector cl
 
 *Classes that wrap numbers.*
 
-* [`biginteger`](https://davidchall.github.io/bignum/reference/biginteger.html) - Arbitrary precision integers: [`25852016738884976640000`](reprex/biginteger.md)
 * [`bigfloat`](https://davidchall.github.io/bignum/reference/bigfloat.html) - High precision numbers: [`0.33333333333333333333333333333333333333333333333333`](reprex/bigfloat.md)
+* [`biginteger`](https://davidchall.github.io/bignum/reference/biginteger.html) - Arbitrary precision integers: [`25852016738884976640000`](reprex/biginteger.md)
 * [`errors`](https://r-quantities.github.io/errors/reference/errors.html) - Numbers with uncertainty: [`1 ± 0.3`](reprex/errors.md)
 * [`num`](https://pillar.r-lib.org/reference/num) - Numbers with formatting: [`1.00`](reprex/num.md)
 * [`quantities`](https://r-quantities.github.io/quantities/reference/quantities.html) - Numbers with units and uncertainty: [`1 ± 0.3 [m/s]`](reprex/quantities.md)

--- a/reprex/bigfloat.md
+++ b/reprex/bigfloat.md
@@ -1,0 +1,31 @@
+``` r
+library(bignum)
+
+bigfloat(-2e34)
+#> <bigfloat[1]>
+#> [1] -2e+34
+
+bigfloat("3.5e65")
+#> <bigfloat[1]>
+#> [1] 3.5e+65
+
+bigfloat(1) / 3
+#> <bigfloat[1]>
+#> [1] 0.3333333
+
+options(bignum.sigfig = 50)
+options(bignum.max_dec_width = Inf)
+bigfloat(1) / 3
+#> <bigfloat[1]>
+#> [1] 0.33333333333333333333333333333333333333333333333333
+
+bigfloat(c(Inf, -Inf, NaN, NA))
+#> <bigfloat[4]>
+#> [1] Inf  -Inf NaN  <NA>
+
+NA_bigfloat_
+#> <bigfloat[1]>
+#> [1] <NA>
+```
+
+<sup>Created on 2021-06-13 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

--- a/reprex/biginteger.md
+++ b/reprex/biginteger.md
@@ -1,0 +1,26 @@
+``` r
+library(bignum)
+
+biginteger(1:3)
+#> <biginteger[3]>
+#> [1] 1 2 3
+
+biginteger(4294967296)
+#> <biginteger[1]>
+#> [1] 4294967296
+
+biginteger("-18446744073709551616")
+#> <biginteger[1]>
+#> [1] -1.844674e+19
+
+options(bignum.max_dec_width = Inf)
+biginteger("-18446744073709551616")
+#> <biginteger[1]>
+#> [1] -18446744073709551616
+
+NA_biginteger_
+#> <biginteger[1]>
+#> [1] <NA>
+```
+
+<sup>Created on 2021-06-13 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>


### PR DESCRIPTION
This PR adds the biginteger and bigfloat classes from the [bignum](https://davidchall.github.io/bignum/index.html) package.